### PR TITLE
Fix grading reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ We are dedicated to provide you with a learning environment that is _rigorous, r
 [stackoverflow]: https://stackoverflow.com
 [duckduckgo]: https://duckduckgo.com
 [synopsis]: #synopsis
-[grading]: grading.md
+[grading]: /grading
 [bachelor]: https://www.cmd-amsterdam.nl/english/
 [faculty]: https://www.amsterdamuas.com/faculty/fdmci/faculty-of-digital-media-and-creative-industries.html
 [university]: https://www.amsterdamuas.com


### PR DESCRIPTION
Hi 👋 

Currently clicking on the grading of 'Assessment 1' or 'Assessment 2' on the Grade section in the main README results in a dead link. I've fixed it to link to the `grading` page instead, as it probably is supposed to.